### PR TITLE
Build fixed. Shibboleth upgrade 3.0.4 to latest (3.2.1).

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN wget -qO - http://pkg.switch.ch/switchaai/SWITCHaai-swdistrib.asc | apt-key 
     && echo "deb http://nginx.org/packages/debian/ buster nginx" > /etc/apt/sources.list.d/nginx.list
 
 # Install Shibboleth, Nginx, and Supervisor
-RUN apt-get update && apt-get install --no-install-recommends -y shibboleth=3.0.4+switchaai2~buster1 supervisor nginx \
+RUN apt-get update && apt-get install --no-install-recommends -y shibboleth supervisor nginx \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Nginx modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:buster-slim AS build
 
 # Install dependencies
 RUN apt-get update \
-  && apt-get install --no-install-recommends -y gnupg2 ca-certificates wget git mercurial build-essential lsb-release devscripts fakeroot quilt libssl-dev libpcre3-dev zlib1g-dev debhelper \
+  && apt-get install --no-install-recommends -y gnupg2 ca-certificates wget git mercurial build-essential lsb-release devscripts fakeroot quilt libssl-dev libpcre3-dev zlib1g-dev debhelper libxml2-utils xsltproc \
   && rm -rf /var/lib/apt/lists/*
 
 # Add Nginx repository and install

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CircleCI](https://circleci.com/gh/pennlabs/docker-shibboleth-sp-nginx.svg?style=shield)](https://circleci.com/gh/pennlabs/docker-shibboleth-sp-nginx)
 [![Docker Pulls](https://img.shields.io/docker/pulls/pennlabs/shibboleth-sp-nginx)](https://hub.docker.com/r/pennlabs/shibboleth-sp-nginx)
 
-This docker image contains Nginx with Shibboleth SP 3.0.4 running on Debian Buster (Slim). The image was built following [these instructions](https://github.com/nginx-shib/nginx-http-shibboleth).
+This docker image contains Nginx with Shibboleth SP 3.x.x running on Debian Buster (Slim). The image was built following [these instructions](https://github.com/nginx-shib/nginx-http-shibboleth).
 
 This image is meant to be used as a base image with local changes overriding the default configs.
 


### PR DESCRIPTION
Changes
======
1) Issue: Cannot be built because of missing dependencies `libxml2-utils` and `xsltproc`. After adding everything works.

2) Shibboleth verson fix `3.0.4+switchaai2~buster1` removed. Tested with latest version (3.2.1) It works correctly.